### PR TITLE
Add new profile link fields to JSON example

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -163,6 +163,8 @@ curl "https://www.castupload.com/api/v1/actor_profiles/123" \
   "instagram_username": "castupload",
   "filmmakers_url": null,
   "sv_url": null,
+  "wikipedia_url": "https://de.wikipedia.org/wiki/My_Page",
+  "agency_profile_url": "https://www.my-agency/my-profile",
   "talent_agency_id": 1,
   "updated_at": "2021-06-22T16:14:11.519+02:00",
   "native_dialect": "rheinisch",


### PR DESCRIPTION
References https://github.com/denkungsart/castupload/pull/6766 and https://github.com/denkungsart/castupload/pull/6719

Changes:
- add `wikipedia_url` and `agency_profile_url` to snippet