### PR TITLE
Add "languages" as allowed field for actor profiles index

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -113,7 +113,7 @@ Parameter | Default | Description
 page | 1 | Page to display - see "Pagination" above 
 include_picture | false | If set to true, the result will include the profile picture thumbnail in a field named `main_picture_url_tile`.
 picture_version | null | Can be set to `original`, `large` or `thumb` to change the included picture version. The picture will be included in a field named `picture_url`. _(Only applies if `include_picture` is true)_
-fields | name,gender | Can be used to modify the fields included in the response. Possible values are: `age`, `gender`, `first_name`, `last_name`, `name`, `professions`.
+fields | name,gender | Can be used to modify the fields included in the response. Possible values are: `age`, `gender`, `first_name`, `last_name`, `name`, `professions`, `languages`.
 order | id | Changes the order of returned results. Possible values are: `id`, `name`, `last_name`
 gender | null | Allows filtering by gender. Possible values are: `m`, `f`, `i`.
 


### PR DESCRIPTION
While doing https://github.com/denkungsart/castupload/pull/7561 (API v2) I noticed that it's possible to pass in `languages` to the API request for actor profiles index. So I added this here to the docs.